### PR TITLE
Update to TETR.IO v9

### DIFF
--- a/io.tetr.tetr.io.yml
+++ b/io.tetr.tetr.io.yml
@@ -18,8 +18,8 @@ modules:
     buildsystem: simple
     sources:
       - type: archive
-        url: https://tetr.io/about/desktop/builds/TETR.IO%20Setup.tar.gz
-        sha256: d400a19cf60014062dcc1a28eb06911bc0d38e659b73377ec0f06d6b7bc0b38a
+        url: https://tetr.io/about/desktop/builds/9/TETR.IO%20Setup.tar.gz
+        sha256: b94dd30c251ac473e82f1a053eb0f33e859ac964b80d8474e17562031c619854
         dest: ./tetr-tarball
       - type: file
         path: ./tetrio-run

--- a/tetrio-run
+++ b/tetrio-run
@@ -5,4 +5,4 @@ then
         FLAGS="$FLAGS --disable-gpu-sandbox"
 fi
 
-env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/bin/tetrio-desktop "$@"
+env TMPDIR=$XDG_CACHE_HOME zypak-wrapper /app/bin/TETR.IO "$@"


### PR DESCRIPTION
Update the download link, hash, and `tetrio-run`